### PR TITLE
Project target framework fix

### DIFF
--- a/Linqor/Linqor.csproj
+++ b/Linqor/Linqor.csproj
@@ -17,8 +17,7 @@
         <RepositoryUrl>https://github.com/dangerozov/linqor</RepositoryUrl>
 
         <LangVersion>9.0</LangVersion>
-        <TargetFrameworks>netstandard1.6.1</TargetFrameworks>
-        <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+        <TargetFramework>netstandard1.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">


### PR DESCRIPTION
Hi Andrew
Microsoft recommends targeting the lowest version of .NET Standard possible.
`System.ValueTuple 4.5.0` supports `.NETStandard 1.0` projects
So the target framework can be downgraded to 1.0
That change will allow you to reference this package to `>=net45` projects (now it's `>=net461`)
Also I don't see any reason to use `<NetStandardImplicitPackageVersion>` [read this](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#netstandardimplicitpackageversion)
PS: you need to use `<TargetFrameworks>` only if you have multiple target frameworks. Otherwise use `<TargetFramework>`.